### PR TITLE
25 integrate aerpaw gateway client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install -y \
   && pip install virtualenv \
   && mkdir /code/
 
+RUN pip install git+https://github.com/AERPAW-Platform-Control/aerpaw-gateway-client.git
+
 WORKDIR /code
 VOLUME ["/code"]
 ENTRYPOINT ["/code/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -121,6 +121,11 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
+Install Aerpaw Gateway Client
+```console
+pip install git+https://github.com/AERPAW-Platform-Control/aerpaw-gateway-client.git
+```
+
 Once completed you should be ready to run the script that launches the Django application using uWSGI
 
 ```console

--- a/env.template
+++ b/env.template
@@ -42,3 +42,6 @@ export OIDC_OP_USER_ENDPOINT='https://cilogon.org/oauth2/userinfo'
 # session renewal period (in seconds)
 export OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS=3600
 
+# Aerpaw Gateway(GW) and Emulab configuration
+export AERPAW_GW_HTTP_PORT=
+export URN_RENCIEMULAB='urn:publicid:IDN+exogeni.net'

--- a/env.template
+++ b/env.template
@@ -43,5 +43,7 @@ export OIDC_OP_USER_ENDPOINT='https://cilogon.org/oauth2/userinfo'
 export OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS=3600
 
 # Aerpaw Gateway(GW) and Emulab configuration
-export AERPAW_GW_HTTP_PORT=
+export AERPAWGW_HOST=''
+export AERPAWGW_PORT=''
+export AERPAWGW_VERSION=''
 export URN_RENCIEMULAB='urn:publicid:IDN+exogeni.net'

--- a/examples/1-raw-x3651.py
+++ b/examples/1-raw-x3651.py
@@ -1,0 +1,24 @@
+"""An example of constructing a profile with one physical node running the default OS.
+
+Instructions:
+Log into your PC and poke around. You have root access via `sudo`. Any work you do on your PC will be lost when it terminates."""
+
+# Import the Portal object.
+import geni.portal as portal
+# Import the ProtoGENI library.
+import geni.rspec.pg as pg
+# Import the Emulab specific extensions.
+import geni.rspec.emulab as emulab
+
+# Create a portal object,
+pc = portal.Context()
+
+# Create a Request object to start building the RSpec.
+request = pc.makeRequestRSpec()
+
+# Node node1
+node1 = request.RawPC('node1')
+node1.hardware_type = "x3651"
+
+# Print the generated rspec
+pc.printRequestRSpec(request)

--- a/examples/2-raw-x3651-with-link.py
+++ b/examples/2-raw-x3651-with-link.py
@@ -1,0 +1,21 @@
+"""An example of constructing a profile with two physical nodes connected by a Link.
+
+Instructions:
+Wait for the profile instance to start, and then log in to either host.
+"""
+
+import geni.portal as portal
+import geni.rspec.pg as rspec
+
+request = portal.context.makeRequestRSpec()
+
+# Create two raw "PC" nodes
+node1 = request.RawPC("node1")
+node2 = request.RawPC("node2")
+node1.hardware_type = "x3651"
+node2.hardware_type = "x3651"
+
+# Create a link between them
+link1 = request.Link(members = [node1, node2])
+
+portal.context.printRequestRSpec()

--- a/experiments/forms.py
+++ b/experiments/forms.py
@@ -3,6 +3,7 @@ from django import forms
 from accounts.models import AerpawUser
 from projects.models import Project
 from reservations.models import Reservation
+from profiles.models import Profile
 from .models import Experiment
 
 
@@ -19,6 +20,13 @@ class ExperimentCreateForm(forms.ModelForm):
         required=True,
         widget=forms.Select(),
         label='Project',
+    )
+
+    profile = forms.ModelChoiceField(
+        queryset=Profile.objects.order_by('name'),
+        required=False,
+        widget=forms.Select(),
+        label='Profile',
     )
 
     class Meta:
@@ -76,6 +84,13 @@ class ExperimentUpdateForm(forms.ModelForm):
         required=False,
         widget=forms.SelectMultiple(),
         label='Experiment Reservations',
+    )
+
+    profile = forms.ModelChoiceField(
+        queryset=Profile.objects.order_by('name'),
+        required=False,
+        widget=forms.Select(),
+        label='Profile',
     )
 
     class Meta:

--- a/experiments/models.py
+++ b/experiments/models.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from accounts.models import AerpawUser
 from projects.models import Project
 from resources.models import ResourceStageChoice
+from profiles.models import Profile
 
 class ReservationStatusChoice(Enum):   # A subclass of Enum
     IDLE = 'Idle'
@@ -31,6 +32,7 @@ class Experiment(models.Model):
     experimenter = models.ManyToManyField(
         AerpawUser, related_name='experiment_of_experimenter'
     )
+
     project = models.ForeignKey(
         Project, related_name='experiment_of_project',null=True, on_delete=models.SET_NULL
     )
@@ -39,7 +41,7 @@ class Experiment(models.Model):
         AerpawUser, related_name='experiment_created_by', null=True, on_delete=models.SET_NULL
     )
     created_date = models.DateTimeField(default=timezone.now)
-    
+
     modified_by = models.ForeignKey(
         AerpawUser, related_name='experiment_modified_by', null=True, on_delete=models.SET_NULL
     )
@@ -52,6 +54,10 @@ class Experiment(models.Model):
     stage=models.CharField(
       max_length=64,
       choices=ResourceStageChoice.choices(),
+    )
+
+    profile = models.ForeignKey(
+        Profile, related_name='experiment_profile', null=True, on_delete=models.SET_NULL
     )
 
     class Meta:

--- a/experiments/urls.py
+++ b/experiments/urls.py
@@ -9,7 +9,8 @@ from .views import(
     experiment_detail,
     experiment_update,
     experiment_delete,
-    experiment_initiate
+    experiment_initiate,
+    experiment_manifest
 )
 
 urlpatterns = [
@@ -19,5 +20,6 @@ urlpatterns = [
     path('<uuid:experiment_uuid>/update', experiment_update, name='experiment_update'),
     path('<uuid:experiment_uuid>/delete', experiment_delete, name='experiment_delete'),
     path('<uuid:experiment_uuid>/initiate', experiment_initiate, name='experiment_initiate'),
+    path('<uuid:experiment_uuid>/manifest', experiment_manifest, name='experiment_manifest'),
     path('', include(('reservations.urls', 'reservations'), namespace='reservations')),
 ]

--- a/experiments/urls.py
+++ b/experiments/urls.py
@@ -8,7 +8,8 @@ from .views import(
     experiment_create,
     experiment_detail,
     experiment_update,
-    experiment_delete
+    experiment_delete,
+    experiment_initiate
 )
 
 urlpatterns = [
@@ -17,5 +18,6 @@ urlpatterns = [
     path('<uuid:experiment_uuid>', experiment_detail, name='experiment_detail'),
     path('<uuid:experiment_uuid>/update', experiment_update, name='experiment_update'),
     path('<uuid:experiment_uuid>/delete', experiment_delete, name='experiment_delete'),
+    path('<uuid:experiment_uuid>/initiate', experiment_initiate, name='experiment_initiate'),
     path('', include(('reservations.urls', 'reservations'), namespace='reservations')),
 ]

--- a/experiments/views.py
+++ b/experiments/views.py
@@ -23,8 +23,8 @@ def experiments(request):
     experiments = get_experiment_list(request)
 
     # emulab cloud:
-    emulab_experiments = get_emulab_instances(request)
-    return render(request, 'experiments.html', {'experiments': emulab_experiments})
+    # emulab_experiments = get_emulab_instances(request)
+    return render(request, 'experiments.html', {'experiments': experiments})
 
 
 def experiment_create(request):

--- a/experiments/views.py
+++ b/experiments/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 
 from .forms import ExperimentCreateForm, ExperimentUpdateForm
 from .models import Experiment
-from .experiments import create_new_experiment, get_experiment_list, update_existing_experiment, delete_existing_experiment
+from .experiments import *
 from experiments.models import Project
 
 
@@ -18,8 +18,13 @@ def experiments(request):
     :param request:
     :return:
     """
+
+    # aerpaw nodes:
     experiments = get_experiment_list(request)
-    return render(request, 'experiments.html', {'experiments': experiments})
+
+    # emulab cloud:
+    emulab_experiments = get_emulab_instances(request)
+    return render(request, 'experiments.html', {'experiments': emulab_experiments})
 
 
 def experiment_create(request):
@@ -56,7 +61,7 @@ def experiment_detail(request, experiment_uuid):
     experiment = get_object_or_404(Experiment, uuid=UUID(str(experiment_uuid)))
     experiment_reservations = experiment.reservation_of_experiment
     request.session['experiment_id'] = experiment.id
-    return render(request, 'experiment_detail.html', 
+    return render(request, 'experiment_detail.html',
     {'experiment': experiment, 'experimenter':experiment.experimenter.all(), 'reservations': experiment_reservations.all()})
 
 

--- a/experiments/views.py
+++ b/experiments/views.py
@@ -18,12 +18,7 @@ def experiments(request):
     :param request:
     :return:
     """
-
-    # aerpaw nodes:
     experiments = get_experiment_list(request)
-
-    # emulab cloud:
-    # emulab_experiments = get_emulab_instances(request)
     return render(request, 'experiments.html', {'experiments': experiments})
 
 
@@ -33,18 +28,18 @@ def experiment_create(request):
     :param request:
     :return:
     """
-    experimenter=request.user
+    experimenter = request.user
     try:
-        project_id=request.session['project_id']
-        project=get_object_or_404(Project, id=project_id)
+        project_id = request.session['project_id']
+        project = get_object_or_404(Project, id=project_id)
     except KeyError:
-        project_qs=Project.objects.filter(project_members=experimenter)
+        project_qs = Project.objects.filter(project_members=experimenter)
         if project_qs:
-            project=project_qs[0]
+            project = project_qs[0]
         else:
             return redirect('/')
-        
-    form = ExperimentCreateForm(request.POST,project=project,experimenter=experimenter)
+
+    form = ExperimentCreateForm(request.POST, project=project, experimenter=experimenter)
     if form.is_valid():
         experiment_uuid = create_new_experiment(request, form)
         return redirect('experiment_detail', experiment_uuid=experiment_uuid)
@@ -71,10 +66,10 @@ def experiment_detail(request, experiment_uuid):
             status = 'booting'  # for better user understanding
 
     return render(request, 'experiment_detail.html',
-    {'experiment': experiment,
-     'experimenter':experiment.experimenter.all(),
-     'experiment_status': status,
-     'reservations': experiment_reservations.all()})
+                  {'experiment': experiment,
+                   'experimenter': experiment.experimenter.all(),
+                   'experiment_status': status,
+                   'reservations': experiment_reservations.all()})
 
 
 def experiment_update(request, experiment_uuid):
@@ -95,7 +90,8 @@ def experiment_update(request, experiment_uuid):
         form = ExperimentUpdateForm(instance=experiment)
     return render(request, 'experiment_update.html',
                   {
-                      'form': form, 'experiment_uuid': str(experiment_uuid), 'experiment_name': experiment.name}
+                      'form': form, 'experiment_uuid': str(experiment_uuid),
+                      'experiment_name': experiment.name}
                   )
 
 
@@ -112,7 +108,9 @@ def experiment_delete(request, experiment_uuid):
         is_removed = delete_existing_experiment(request, experiment)
         if is_removed:
             return redirect('experiments')
-    return render(request, 'experiment_delete.html', {'experiment': experiment, 'experimenter':experiment.experimenter.all(), 'experiment_reservations': experiment_reservations})
+    return render(request, 'experiment_delete.html',
+                  {'experiment': experiment, 'experimenter': experiment.experimenter.all(),
+                   'experiment_reservations': experiment_reservations})
 
 
 def experiment_initiate(request, experiment_uuid):
@@ -152,9 +150,10 @@ def experiment_manifest(request, experiment_uuid):
     if manifest is not None:
         logger.warning(manifest)
         return render(request, 'experiment_manifest.html',
-                  {'experiment': experiment,
-                   'rspec': manifest.rspec,
-                   'vnodes': manifest.vnodes})
+                      {'experiment': experiment,
+                       'rspec': manifest.rspec,
+                       'vnodes': manifest.vnodes})
     else:
-        logger.error('not emulab experiment or not ready, temporary redirect back, need better handling')
+        logger.error(
+            'not emulab experiment or not ready, temporary redirect back, need better handling')
         return redirect('experiment_detail', experiment_uuid=experiment_uuid)

--- a/profiles/profiles.py
+++ b/profiles/profiles.py
@@ -151,7 +151,7 @@ def query_emulab_profile(request, emulab_profile_name):
         return emulab_profile
     except ApiException as e:
         print("Exception when calling ProfileApi->query_profile: %s\n" % e)
-        raise Exception(e)
+        return None
 
 
 def create_new_emulab_profile(request, profile):

--- a/profiles/profiles.py
+++ b/profiles/profiles.py
@@ -5,7 +5,12 @@ from django.utils import timezone
 from .models import Profile
 from accounts.models import AerpawUser
 from projects.models import Project
+import swagger_client as AerpawGW
+from swagger_client.rest import ApiException
+from datetime import datetime
+import logging
 
+logger = logging.getLogger(__name__)
 
 def create_new_profile(request, form):
     """
@@ -16,8 +21,9 @@ def create_new_profile(request, form):
     """
     profile = Profile()
     profile.uuid = uuid.uuid4()
-    request.session['profile_uuid'] = profile.uuid 
+    request.session['profile_uuid'] = profile.uuid
     profile.name = form.data.getlist('name')[0]
+
     try:
         profile.description = form.data.getlist('description')[0]
     except ValueError as e:
@@ -32,10 +38,12 @@ def create_new_profile(request, form):
 
     profile.created_by = request.user
     profile.created_date = timezone.now()
-    profile.save()
+    profile.project = Project.objects.get(id=int(form.data.getlist('project')[0]))
 
+    create_new_emulab_profile(request, profile)
+
+    profile.save()
     try:
-        profile.project = Project.objects.get(id=int(form.data.getlist('project')[0]))  
         profile.project.profile_of_project.add(profile)
         profile.save()
     except ValueError as e:
@@ -53,6 +61,7 @@ def create_new_profile(request, form):
     #profile.save()
 
     return str(profile.uuid)
+
 
 def update_existing_profile(request, profile, form):
     """
@@ -75,6 +84,7 @@ def delete_existing_profile(request, profile):
     :return:
     """
     try:
+        delete_emulab_profile(request, profile)
         profile.delete()
         return True
     except Exception as e:
@@ -93,3 +103,70 @@ def get_profile_list(request):
     else:
         profiles = Profile.objects.order_by('name')
     return profiles
+
+
+def query_emulab_profile(request, emulab_profile_name):
+    """
+    Query emulab profile
+
+    :param request: in case we need user info later
+    :param emulab_profile_name:
+    :return emulab_profile:
+    """
+    api_instance = AerpawGW.ProfileApi()
+    print(emulab_profile_name)
+    try:
+        # query specific profile
+        emulab_profile = api_instance.query_profile(profile=emulab_profile_name)
+        print(emulab_profile)
+        return emulab_profile
+    except ApiException as e:
+        print("Exception when calling ProfileApi->query_profile: %s\n" % e)
+        raise Exception(e)
+
+
+def create_new_emulab_profile(request, profile):
+    """
+    Create new Profile on Emulab
+
+    :param request: in case we need user info later
+    :param profile:
+    :return:
+    """
+    emulab_profile_name = '{}-{}'.format(profile.project.name, profile.name)
+
+    # create on emulab
+    api_instance = AerpawGW.ProfileApi()
+    body = AerpawGW.Profile(name=emulab_profile_name, script=profile.profile)
+    logger.debug(body)
+    try:
+        api_response = api_instance.create_profile(body)
+        print(api_response)
+    except ApiException as e:
+        raise Exception("Exception when calling Gateway->create_profile: %s\n" % e)
+
+    # verify created profile on emulab by querying it
+    try:
+        profile_created = query_emulab_profile(request, emulab_profile_name)
+        if profile_created is None:
+            raise Exception("failed to query the created emulab profile")
+    except Exception as e:
+        raise Exception("failed to query the created emulab profile")
+
+
+def delete_emulab_profile(request, profile):
+    """
+    Delte profile in emulab cloud
+
+    :param request: in case we need user info later
+    :param profile:
+    :return
+    """
+
+    emulab_profile_name = '{}-{}'.format(profile.project.name, profile.name)
+    api_instance = AerpawGW.ProfileApi()
+    try:
+        # delete profile
+        api_instance.delete_profile(emulab_profile_name)
+    except ApiException as e:
+        print("Exception when calling ProfileApi->delete_profile: %s\n" % e)

--- a/profiles/profiles.py
+++ b/profiles/profiles.py
@@ -157,7 +157,7 @@ def create_new_emulab_profile(request, profile):
     :param profile:
     :return:
     """
-    emulab_profile_name = '{}-{}'.format(profile.project.name, profile.name)
+    emulab_profile_name = get_emulab_profile_name(profile.project.name, profile.name)
 
     # create on emulab
     api_instance = AerpawGW.ProfileApi()
@@ -178,19 +178,28 @@ def create_new_emulab_profile(request, profile):
         raise Exception("failed to query the created emulab profile")
 
 
-def delete_emulab_profile(request, profile):
+def delete_emulab_profile(request, profile, name_to_delete=None):
     """
     Delte profile in emulab cloud
 
     :param request: in case we need user info later
     :param profile:
+    :param name_to_delete: in case of user updates the name in profile,
+                            we will need to use the oldnname to delete
     :return
     """
 
-    emulab_profile_name = '{}-{}'.format(profile.project.name, profile.name)
+    if name_to_delete is None:
+        emulab_profile_name = get_emulab_profile_name(profile.project.name, profile.name)
+    else:
+        emulab_profile_name = get_emulab_profile_name(profile.project.name, name_to_delete)
     api_instance = AerpawGW.ProfileApi()
     try:
         # delete profile
         api_instance.delete_profile(emulab_profile_name)
     except ApiException as e:
         print("Exception when calling ProfileApi->delete_profile: %s\n" % e)
+
+
+def get_emulab_profile_name(projectname, profilename):
+    return '{}-{}'.format(projectname, profilename)

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -8,7 +8,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 
 from .forms import ProfileCreateForm, ProfileUpdateForm
 from .models import Profile
-from .profiles import create_new_profile, get_profile_list, update_existing_profile, delete_existing_profile
+from .profiles import *
 
 
 def profiles(request):
@@ -45,7 +45,7 @@ def profile_detail(request, profile_uuid):
     :return:
     """
     profile = get_object_or_404(Profile, uuid=UUID(str(profile_uuid)))
-    return render(request, 'profile_detail.html', 
+    return render(request, 'profile_detail.html',
     {'profile': profile})
 
 
@@ -58,8 +58,11 @@ def profile_update(request, profile_uuid):
     """
     profile = get_object_or_404(Profile, uuid=UUID(str(profile_uuid)))
     if request.method == "POST":
+        old_profile_name = profile.name
         form = ProfileUpdateForm(request.POST, instance=profile)
         if form.is_valid():
+            if is_emulab_profile(profile.stage):
+                delete_emulab_profile(request, profile, old_profile_name)
             profile = form.save(commit=False)
             profile_uuid = update_existing_profile(request, profile, form)
             return redirect('profile_detail', profile_uuid=str(profile.uuid))

--- a/reservations/reservations.py
+++ b/reservations/reservations.py
@@ -9,8 +9,8 @@ from resources.models import Resource
 from resources.resources import remove_units, update_units
 from .models import Reservation,ReservationStatusChoice
 from accounts.models import AerpawUser
-import swagger_client as AerpawGW
-from swagger_client.rest import ApiException
+import aerpawgw_client
+from aerpawgw_client.rest import ApiException
 from datetime import datetime
 import logging
 
@@ -121,10 +121,10 @@ def create_new_emulab_reservation(request, reservation):
     :return:
     """
     # create on emulab
-    api_instance = AerpawGW.ReservationApi()
+    api_instance = aerpawgw_client.ReservationApi()
     start_timestamp = str(int(datetime.fromisoformat(reservation.start_date).timestamp()))
     end_timestamp = str(int(datetime.fromisoformat(reservation.end_date).timestamp()))
-    body = AerpawGW.Reservation(type=reservation.resource.name,
+    body = aerpawgw_client.Reservation(type=reservation.resource.name,
                                 nodes=int(reservation.units),
                                 experiment=reservation.experiment.name,
                                 start=start_timestamp,
@@ -157,7 +157,7 @@ def query_emulab_reservation(request, experiment, resourcetype):
     :param experiment:
     :return emulab_reservation:
     """
-    api_instance = AerpawGW.ReservationApi()
+    api_instance = aerpawgw_client.ReservationApi()
     try:
         # check if there is reserveration matches the experiment and resourcetype
         emulab_reservations = api_instance.get_reservation()
@@ -187,7 +187,7 @@ def delete_emulab_reservation(request, experiment, resourcetype):
             return
     except Exception as e:
         raise Exception("failed to query the created emulab reservation")
-    api_instance = AerpawGW.ReservationApi()
+    api_instance = aerpawgw_client.ReservationApi()
     try:
         # delete reservation
         api_instance.delete_reservation(reservation_cloud_uuid)

--- a/reservations/reservations.py
+++ b/reservations/reservations.py
@@ -9,6 +9,13 @@ from resources.models import Resource
 from resources.resources import remove_units, update_units
 from .models import Reservation,ReservationStatusChoice
 from accounts.models import AerpawUser
+import swagger_client as AerpawGW
+from swagger_client.rest import ApiException
+from datetime import datetime
+import logging
+
+logger = logging.getLogger(__name__)
+
 
 def create_new_reservation(request, form, experiment_uuid):
     """
@@ -26,7 +33,7 @@ def create_new_reservation(request, form, experiment_uuid):
         print(e)
         reservation.description = None
 
-    reservation.experiment=get_object_or_404(Experiment, uuid=UUID(str(experiment_uuid)))  
+    reservation.experiment = get_object_or_404(Experiment, uuid=UUID(str(experiment_uuid)))
 
     reservation.resource = form.cleaned_data.get('resource')
     reservation.units = form.cleaned_data.get('units')
@@ -36,10 +43,12 @@ def create_new_reservation(request, form, experiment_uuid):
 
     is_available = remove_units(reservation.resource,int(reservation.units),reservation.start_date,reservation.end_date)
     if not is_available:
-        reservation.state=ReservationStatusChoice.FAILURE.value
+        reservation.state = ReservationStatusChoice.FAILURE.value
         print("The resource is not available at this time")
     else:
-        reservation.state=ReservationStatusChoice.SUCCESS.value
+        create_new_emulab_reservation(request, reservation)
+        delete_emulab_reservation(request, reservation.experiment.name, reservation.resource.name)
+        reservation.state = ReservationStatusChoice.SUCCESS.value
 
     reservation.save()
     reservation.experiment.reservation_of_experiment.add(reservation)
@@ -59,11 +68,12 @@ def update_existing_reservation(request, original_units, reservation, form):
     reservation.start_date = form.cleaned_data.get('start_date')
     reservation.end_date = form.cleaned_data.get('end_date')
     is_available = update_units(reservation.resource,int(reservation.units),original_units,reservation.start_date,reservation.end_date)
+
     if not is_available:
-        reservation.state=ReservationStatusChoice.FAILURE.value
+        reservation.state = ReservationStatusChoice.FAILURE.value
         print("The resource is not available at this time")
     else:
-        reservation.state=ReservationStatusChoice.SUCCESS.value
+        reservation.state = ReservationStatusChoice.SUCCESS.value
 
     reservation.modified_by = request.user
     reservation.modified_date = timezone.now()
@@ -98,7 +108,91 @@ def get_reservation_list(request):
     if request.user.is_superuser:
         reservations = Reservation.objects.order_by('name')
     else:
-        experiment_id=request.session['experiment_id']
-        ex=Experiment.objects.get(id=experiment_id)
+        experiment_id = request.session['experiment_id']
+        ex = Experiment.objects.get(id=experiment_id)
         reservations = Reservation.objects.filter(experiment=ex).order_by('name')
     return reservations
+
+
+def create_new_emulab_reservation(request, reservation):
+    """
+    Create new reservation on Emulab
+
+    :param request: in case we need user info later
+    :param reservation:
+    :return:
+    """
+    # create on emulab
+    api_instance = AerpawGW.ReservationApi()
+    start_timestamp = str(int(datetime.fromisoformat(reservation.start_date).timestamp()))
+    end_timestamp = str(int(datetime.fromisoformat(reservation.end_date).timestamp()))
+    body = AerpawGW.Reservation(type=reservation.resource.name,
+                                nodes=int(reservation.units),
+                                experiment=reservation.experiment.name,
+                                start=start_timestamp,
+                                end=end_timestamp)
+    logger.warning(body)
+    try:
+        api_response = api_instance.create_reservation(body)
+        print(api_response)
+    except ApiException as e:
+        raise Exception("Exception when calling Gateway->create_reservation: %s\n" % e)
+
+    # verify created reservation on emulab by querying it
+    try:
+        reservation_cloud_uuid = query_emulab_reservation(request,
+                                                          reservation.experiment.name,
+                                                          reservation.resource.name
+                                                          )
+        if reservation_cloud_uuid is None:
+            raise Exception("failed to query the created emulab reservation")
+    except Exception as e:
+        raise Exception("failed to query the created emulab reservation")
+
+
+def query_emulab_reservation(request, experiment, resourcetype):
+    """
+    Query emulab reservation
+
+    :param request: in case we need user info later
+    :param resourcetype:
+    :param experiment:
+    :return emulab_reservation:
+    """
+    api_instance = AerpawGW.ReservationApi()
+    try:
+        # check if there is reserveration matches the experiment and resourcetype
+        emulab_reservations = api_instance.get_reservation()
+        for reservation in emulab_reservations:
+            if reservation.experiment == experiment and reservation.type == resourcetype:
+                return reservation.uuid
+    except ApiException as e:
+        print("Exception when calling ProfileApi->query_profile: %s\n" % e)
+        raise Exception(e)
+
+    return None
+
+
+def delete_emulab_reservation(request, experiment, resourcetype):
+    """
+    Query emulab reservation
+
+    :param request: in case we need user info later
+    :param resourcetype:
+    :param experiment:
+    :return emulab_reservation:
+    """
+    # find the reservation and get the uuid
+    try:
+        reservation_cloud_uuid = query_emulab_reservation(request, experiment, resourcetype)
+        if reservation_cloud_uuid is None:
+            return
+    except Exception as e:
+        raise Exception("failed to query the created emulab reservation")
+    api_instance = AerpawGW.ReservationApi()
+    try:
+        # delete reservation
+        api_instance.delete_reservation(reservation_cloud_uuid)
+    except ApiException as e:
+        print("Exception when calling ReservationApi->delete_reservation: %s\n" % e)
+    return

--- a/reservations/reservations.py
+++ b/reservations/reservations.py
@@ -46,8 +46,6 @@ def create_new_reservation(request, form, experiment_uuid):
         reservation.state = ReservationStatusChoice.FAILURE.value
         print("The resource is not available at this time")
     else:
-        create_new_emulab_reservation(request, reservation)
-        delete_emulab_reservation(request, reservation.experiment.name, reservation.resource.name)
         reservation.state = ReservationStatusChoice.SUCCESS.value
 
     reservation.save()

--- a/resources/models.py
+++ b/resources/models.py
@@ -34,6 +34,7 @@ class ResourceLocationChoice(Enum):   # A subclass of Enum
     LAKEWHEELER = 'LakeWheeler'
     CENTENNIAL = 'Centennial'
     CARY = 'Cary'
+    RENCIEMULAB = 'RENCIEmulab'   # need correspondent entry in .env for the urn
     OTHERS = 'Others'
     @classmethod
     def choices(cls):
@@ -57,7 +58,7 @@ class Resource(models.Model):
       max_length=64,
       choices=ResourceLocationChoice.choices(),
     )
-    
+
     stage=models.CharField(
       max_length=64,
       choices=ResourceStageChoice.choices(),
@@ -77,13 +78,13 @@ class Resource(models.Model):
       return self.name
 
     def is_units_available(self):
-      return (self.units > 0) 
+      return (self.units > 0)
 
     def is_units_available_reservation(self, count):
-      return (self.units - count > 0) 
+      return (self.units - count > 0)
 
     def is_correct_stage(self,stage):
-      return (stage == self.stage) 
+      return (stage == self.stage)
 
     def get_resource_stage(self):
       return self.stage

--- a/resources/resources.py
+++ b/resources/resources.py
@@ -9,7 +9,11 @@ from django.db.models import Q
 
 from .models import Resource
 from accounts.models import AerpawUser
-from reservations.models import Reservation,ReservationStatusChoice
+from reservations.models import Reservation, ReservationStatusChoice
+import swagger_client as AerpawGW
+from swagger_client.rest import ApiException
+import logging
+logger = logging.getLogger(__name__)
 
 
 def create_new_resource(request, form):
@@ -123,6 +127,7 @@ def is_resource_available_time(resource, start_time, end_time):
     reserved_units = get_reserved_units(resource,start_time,end_time)
     return resource.is_units_available_reservation(reserved_units)
 
+
 def get_reserved_units(resource,start,end):
     qs0 = Reservation.objects.filter(state=ReservationStatusChoice.SUCCESS.value)
     qs1 = qs0.filter(start_date__lte=end)
@@ -133,9 +138,11 @@ def get_reserved_units(resource,start,end):
         units += rs.units
     return units
 
+
 def update_units(resource, updated_units, original_units, start_time, end_time, save=True):
       count = updated_units - original_units
       return remove_units(resource, count, start_time, end_time)
+
 
 def remove_units(resource, count, start_time, end_time, save=True):
     remove = is_resource_available_time(resource, start_time, end_time)
@@ -151,3 +158,99 @@ def remove_units(resource, count, start_time, end_time, save=True):
         if save == True:
             resource.save()
     return remove
+
+
+def import_cloud_resources(request):
+    """
+    Import cloud resources to portal
+
+    :param request:
+    :param form:
+    :return:
+    """
+    emulab_resources = get_emulab_resource_list(request)
+    total_cloud_resources = {}
+    avail_cloud_resources = {}
+
+    for emulab_node in emulab_resources:
+        if emulab_node.type in total_cloud_resources:
+            total_cloud_resources[emulab_node.type] += 1
+            if emulab_node.available is True:
+                avail_cloud_resources[emulab_node.type] += 1
+        else:
+            total_cloud_resources[emulab_node.type] = 1
+            if emulab_node.available is True:
+                avail_cloud_resources[emulab_node.type] = 1
+            else:
+                avail_cloud_resources[emulab_node.type] = 0
+
+    logger.warning("total_cloud_resources:{}".format(total_cloud_resources))
+    logger.warning("avail_cloud_resources:{}".format(avail_cloud_resources))
+
+    # create or update resources in database
+    for key in total_cloud_resources.keys():
+        create_or_update_cloud_resource(request, key,
+                                        total_cloud_resources[key],
+                                        avail_cloud_resources[key])
+
+    # delete resources if they are no longer on emulab
+    existing_resources = get_resource_list(request)
+    for resource in existing_resources:
+        if resource.description == 'Emulab nodes' \
+                and resource.resourceType.upper() == 'CLOUD'\
+                and resource.name not in total_cloud_resources.keys():
+            logger.warning('Emulab resource \'{}\' no longer exists, deleting it'.format(resource.name))
+            delete_existing_resource(request, resource)
+
+
+def create_or_update_cloud_resource(request, name, units, avail_units):
+    """
+
+    :param request:
+    :param name:
+    :param units:
+    :param avail_units:
+    :return:
+    """
+
+    existing_resources = get_resource_list(request)
+    for resource in existing_resources:
+        if resource.name == name and resource.units != units:
+            resource.units = units
+            # resource.availableUnits = avail_units
+            resource.modified_date = timezone.now()
+            resource.save()
+            logger.warning('Emulab resource \'{}\' is updated'.format(resource.name))
+            return
+    # there was no such resource, let's create a new one
+    newresource = Resource()
+    newresource.uuid = uuid.uuid4()
+    newresource.name = name
+    newresource.description = 'Emulab nodes'
+    newresource.units = units
+    newresource.availableUnits = avail_units
+    newresource.resourceType = 'Cloud'
+    newresource.stage = 'Development'
+    newresource.location = 'DCS'
+    newresource.save()
+    logger.warning('Emulab resource \'{}\' is created'.format(newresource.name))
+    return
+
+
+def get_emulab_resource_list(request):
+    """
+    Query emulab resource
+
+    :param request: in case we need user info later
+    :return emulab_resources:
+    """
+    api_instance = AerpawGW.ResourcesApi()
+    try:
+        # list resources
+        api_response = api_instance.list_resources()
+        logger.info(api_response)
+        return api_response.nodes
+    except ApiException as e:
+        logger.error("Exception when calling ResourcesApi->list_resources: %s\n" % e)
+        raise Exception(e)
+

--- a/resources/resources.py
+++ b/resources/resources.py
@@ -176,6 +176,7 @@ def import_cloud_resources(request):
     total_cloud_resources = {}
     avail_cloud_resources = {}
 
+    logger.warning('parsing emulab resources:')
     for emulab_node in emulab_resources:
         end_index = emulab_node.component_id.find('node')  # "urn:publicid:IDN+exogeni.net+node+pc1"
         location_urn = emulab_node.component_id[:end_index-1]

--- a/resources/resources.py
+++ b/resources/resources.py
@@ -215,12 +215,13 @@ def create_or_update_cloud_resource(request, name, units, avail_units):
 
     existing_resources = get_resource_list(request)
     for resource in existing_resources:
-        if resource.name == name and resource.units != units:
-            resource.units = units
-            # resource.availableUnits = avail_units
-            resource.modified_date = timezone.now()
-            resource.save()
-            logger.warning('Emulab resource \'{}\' is updated'.format(resource.name))
+        if resource.name == name:
+            if resource.units != units:
+                # resource.availableUnits = avail_units # portal calculates its own avail_units
+                resource.units = units
+                resource.modified_date = timezone.now()
+                resource.save()
+                logger.warning('Emulab resource \'{}\' is updated'.format(resource.name))
             return
     # there was no such resource, let's create a new one
     newresource = Resource()

--- a/resources/resources.py
+++ b/resources/resources.py
@@ -1,5 +1,5 @@
 import uuid
-
+import os
 from django.utils import timezone
 from datetime import datetime, timedelta
 
@@ -232,7 +232,7 @@ def create_or_update_cloud_resource(request, name, units, avail_units):
     newresource.availableUnits = avail_units
     newresource.resourceType = 'Cloud'
     newresource.stage = 'Development'
-    newresource.location = 'DCS'
+    newresource.location = 'RENCIEmulab'
     newresource.save()
     logger.warning('Emulab resource \'{}\' is created'.format(newresource.name))
     return
@@ -255,3 +255,16 @@ def get_emulab_resource_list(request):
         logger.error("Exception when calling ResourcesApi->list_resources: %s\n" % e)
         raise Exception(e)
 
+
+def emulab_location_to_urn(location):
+    if location == 'RENCIEmulab':
+        return os.getenv('URN_RENCIEMULAB')
+    else:
+        raise Exception('unknown location')
+
+
+def emulab_urn_to_location(urn):
+    if urn == os.getenv('URN_RENCIEMULAB'):
+        return 'RENCIEmulab'
+    else:
+        raise Exception('unknown urn')

--- a/resources/resources.py
+++ b/resources/resources.py
@@ -10,8 +10,8 @@ from django.db.models import Q
 from .models import Resource
 from accounts.models import AerpawUser
 from reservations.models import Reservation, ReservationStatusChoice
-import swagger_client as AerpawGW
-from swagger_client.rest import ApiException
+import aerpawgw_client
+from aerpawgw_client.rest import ApiException
 import logging
 logger = logging.getLogger(__name__)
 
@@ -168,6 +168,10 @@ def import_cloud_resources(request):
     :param form:
     :return:
     """
+    if not os.getenv('AERPAWGW_HOST') \
+            or not os.getenv('AERPAWGW_PORT') \
+            or not os.getenv('AERPAWGW_VERSION'):
+        return
     emulab_resources = get_emulab_resource_list(request)
     total_cloud_resources = {}
     avail_cloud_resources = {}
@@ -254,7 +258,7 @@ def get_emulab_resource_list(request):
     :param request: in case we need user info later
     :return emulab_resources:
     """
-    api_instance = AerpawGW.ResourcesApi()
+    api_instance = aerpawgw_client.ResourcesApi()
     try:
         # list resources
         api_response = api_instance.list_resources()

--- a/resources/views.py
+++ b/resources/views.py
@@ -11,7 +11,7 @@ from django.forms.models import model_to_dict
 
 from .forms import ResourceCreateForm, ResourceChangeForm
 from .models import Resource
-from .resources import create_new_resource, get_resource_list, update_existing_resource, delete_existing_resource, get_all_reserved_units
+from .resources import *
 
 import json
 
@@ -50,6 +50,7 @@ def resources(request):
     :param request:
     :return:
     """
+    import_cloud_resources(request)
     resources = get_resource_list(request)
     resources_json = get_resources_json(resources)
     reserved_resource = get_all_reserved_units(24, 2)

--- a/templates/experiments/experiment_detail.html
+++ b/templates/experiments/experiment_detail.html
@@ -68,6 +68,11 @@
             <tr>
               <td>Experiment Status</td>
               <td>{{ experiment_status }}</td>
+              <td>
+                <button class="btn btn-success mr-2">
+                  <a href="{% url 'experiment_manifest' experiment_uuid=experiment.uuid %}" class="unlink">Manifest</a>
+                </button>
+              </td>
             </tr>
           </table>
           <button class="btn btn-success mr-2">

--- a/templates/experiments/experiment_detail.html
+++ b/templates/experiments/experiment_detail.html
@@ -61,6 +61,14 @@
               <td>Modified Date</td>
               <td>{{ experiment.modified_date }}</td>
             </tr>
+            <tr>
+              <td>Profile</td>
+              <td>{{ experiment.profile }}</td>
+            </tr>
+            <tr>
+              <td>Experiment Status</td>
+              <td>{{ experiment_status }}</td>
+            </tr>
           </table>
           <button class="btn btn-success mr-2">
             <a href="{% url 'experiment_update' experiment_uuid=experiment.uuid %}" class="unlink">Update</a>
@@ -70,6 +78,9 @@
           </button>
           <button class="btn btn-danger">
             <a href="{% url 'experiment_delete' experiment_uuid=experiment.uuid %}" class="unlink">Delete</a>
+          </button>
+          <button class="btn btn-success mr-2">
+            <a href="{% url 'experiment_initiate' experiment_uuid=experiment.uuid %}" class="unlink">Initiate/Terminate</a>
           </button>
         </div>
     {% else %}

--- a/templates/experiments/experiment_initiate.html
+++ b/templates/experiments/experiment_initiate.html
@@ -2,13 +2,12 @@
 {% load static %}
 
 {% block title %}
-    Delete: {{ experiment.name }}
+    Initiate/Stop: {{ experiment.name }}
 {% endblock %}
 
 {% block content %}
     {% if user.is_authenticated %}
-        <div class="container">
-            <div class="post">
+       <div class="container">
                 <h2>Initiate or Terminate "{{ experiment.name }}"</h2>
                 <table class="table table-striped table-bordered my-4">
                   <tr>

--- a/templates/experiments/experiment_initiate.html
+++ b/templates/experiments/experiment_initiate.html
@@ -16,11 +16,7 @@
                   </tr>
                   <tr>
                     <td>Project</td>
-                    <td>
-                      {% for member in project%}
-                        {{ member }},
-                      {% endfor %}
-                    </td>
+                    <td>{{ experiment.project }}</td>
                   </tr>
                   <tr>
                     <td>Experiment Members</td>

--- a/templates/experiments/experiment_initiate.html
+++ b/templates/experiments/experiment_initiate.html
@@ -1,0 +1,64 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}
+    Delete: {{ experiment.name }}
+{% endblock %}
+
+{% block content %}
+    {% if user.is_authenticated %}
+        <div class="container">
+            <div class="post">
+                <h2>Initiate or Terminate "{{ experiment.name }}"</h2>
+                <table class="table table-striped table-bordered my-4">
+                  <tr>
+                    <td>Description</td>
+                    <td>{{ experiment.description }}</td>
+                  </tr>
+                  <tr>
+                    <td>Project</td>
+                    <td>
+                      {% for member in project%}
+                        {{ member }},
+                      {% endfor %}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Experiment Members</td>
+                    <td>
+                      {% for member in experimenter%}
+                        {{ member }},
+                      {% endfor %}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Created By</td>
+                    <td>{{ experiment.created_by }}</td>
+                  </tr>
+                  <tr>
+                    <td>Created Date</td>
+                    <td>{{ experiment.created_date }}</td>
+                  </tr>
+                  <tr>
+                    <td>Modified By</td>
+                    <td>{{ experiment.modified_by }}</td>
+                  </tr>
+                  <tr>
+                    <td>Modified Date</td>
+                    <td>{{ experiment.modified_date }}</td>
+                  </tr>
+                </table>
+            </div>
+            <form method="POST" class="post-form">
+                {% csrf_token %}
+                <input class="btn btn-success mr-2" type="submit" value="Initiate/Terminate"/>
+                <a href="{% url 'experiment_detail' experiment_uuid=experiment.uuid %}" class="btn btn-secondary">Back</a>
+            </form>
+
+        </div>
+    {% else %}
+        <div class="container">
+            <p>You are not currently logged in or not authorized to view this page</p>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/templates/experiments/experiment_manifest.html
+++ b/templates/experiments/experiment_manifest.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}
+    Manifest: {{ experiment.name }}
+{% endblock %}
+
+{% block content %}
+    {% if user.is_authenticated %}
+        <div class="container">
+                <h2>Manifest of "{{ experiment.name }}"</h2>
+                <table class="table table-striped table-bordered my-4">
+                  <tr>
+                    <td>Rspec</td>
+                    <td>{{ rspec }}</td>
+                  </tr>
+                  <tr>
+                    <td>Nodes</td>
+                    <td>
+                      {% for node in vnodes%}
+                        {{ node }},
+                      {% endfor %}
+                    </td>
+                  </tr>
+                </table>
+                <button class="btn btn-secondary mr-2">
+                    <a href="{% url 'experiment_detail' experiment_uuid=experiment.uuid %}" class="unlink">Back</a>
+                </button>
+        </div>
+    {% else %}
+        <div class="container">
+            <p>You are not currently logged in or not authorized to view this page</p>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/templates/profiles/profile_update.html
+++ b/templates/profiles/profile_update.html
@@ -8,7 +8,7 @@
 {% block content %}
     {% if user.is_authenticated %}
         <div class="container">
-            <h2>Update Resource</h2>
+            <h2>Update Profile</h2>
             <form method="POST" class="form-group">
                 {% csrf_token %}
                 {{ form.as_p }}


### PR DESCRIPTION
Resolve #25 

Integrating aerpaw-gateway-client into portal, so user can initiate experiment instance on Emulab from portal if the aerpaw-gateway is connected (some new env are introduced)

Functions including
- list resources of emulab
- create/delete profile on emulab
- start/stop experiment on emulab
- query status and manifest of experiment on emulab

Please note that aerpaw-gateway-client must be installed first in the setup steps. (Updated in README.md)
`pip install git+https://github.com/AERPAW-Platform-Control/aerpaw-gateway-client.git`