### PR TITLE
20 add groups permissions

### DIFF
--- a/base/settings.py
+++ b/base/settings.py
@@ -209,3 +209,11 @@ LOGGING = {
 
 # Auth user model (custom user account)
 AUTH_USER_MODEL = 'accounts.AerpawUser'
+
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+EMAIL_HOST = os.getenv('EMAIL_HOST')
+EMAIL_PORT = os.getenv('EMAIL_PORT')
+EMAIL_HOST_USER = os.getenv('EMAIL_HOST_USER')
+EMAIL_HOST_PASSWORD = os.getenv('EMAIL_HOST_PASSWORD')
+EMAIL_USE_TLS = True
+EMAIL_USE_SSL = False

--- a/projects/forms.py
+++ b/projects/forms.py
@@ -92,6 +92,12 @@ class ProjectUpdateForm(forms.ModelForm):
         label='Add project members emails',
     )
 
+    project_pending_member_emails = forms.CharField(
+        widget=forms.TextInput(attrs={'size': 60}),
+        required=False,
+        label='Pending members',
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         project = self.instance
@@ -105,6 +111,7 @@ class ProjectUpdateForm(forms.ModelForm):
         fields = (
             'name',
             'description',
+            'project_pending_member_emails',
             #'principal_investigator',
             #'project_members',
         )

--- a/projects/models.py
+++ b/projects/models.py
@@ -26,7 +26,7 @@ class Project(models.Model):
     project_members = models.ManyToManyField(
         AerpawUser, related_name='projects'
     )
-    project_pending_member_emails = models.CharField(max_length=140,default='')
+    project_pending_member_emails = models.CharField(max_length=280,default='')
     created_by = models.ForeignKey(
         User, related_name='project_created_by', on_delete=models.CASCADE, null=True, blank=True
     )

--- a/projects/projects.py
+++ b/projects/projects.py
@@ -60,24 +60,31 @@ def update_project_members(project, project_member_email_list):
     # clear current project membership
     #project.project_members.clear()
     # add members from project_member_id_update_list
+    project.project_pending_member_emails = ''
+    project.save()
+    updated_pending_email_list=[]
     for member_email in project_member_email_list:
         try:
             project_member = AerpawUser.objects.get(oidc_claim_email=member_email)
             project.project_members.add(project_member)
         except AerpawUser.DoesNotExist:
-            project.project_pending_member_emails = project.project_pending_member_emails + member_email+',' 
+            updated_pending_email_list.append(member_email)
+    
+    seen = set()
+    unique_list = []
+    for email in updated_pending_email_list:
+        if email not in seen:
+            unique_list.append(email)
+            seen.add(email)
+    project.project_pending_member_emails = ",".join(str(x) for x in unique_list)
     if project.project_pending_member_emails != '':
-        send_pending_memeber_emails(project.project_pending_member_emails)
+        send_pending_memeber_emails(unique_list)
 
-    project.save()
-
-def send_pending_memeber_emails(pending_member_emails):
+def send_pending_memeber_emails(pending_member_emails_list):
     subject = 'AERPAW project sign up'
     message = 'You received this email because a project PI has added you to the project. Please go to aerpaw.org to login and signup.' 
     email_from = settings.EMAIL_HOST_USER
-    recipient_list=pending_member_emails.split(',')
-    print(email_from)
-    print(recipient_list)
+    recipient_list=pending_member_emails_list
     send_mail( subject, message, email_from, recipient_list )
     
 
@@ -115,9 +122,14 @@ def update_existing_project(request, project, form):
         print(e)
 
     try:
-        project_member_email_list = form.data.getlist('add_project_members')[0].split(',')
-        update_project_members(project, project_member_email_list)
-        project.save()
+        pending_member_emails = form.data.getlist('add_project_members')[0]
+        if project.project_pending_member_emails != '':
+            pending_member_emails = project.project_pending_member_emails + ',' + pending_member_emails
+        print("pending_member_emails: " + project.project_pending_member_emails)
+        if pending_member_emails != '':
+            project_member_email_list = pending_member_emails.split(',')
+            update_project_members(project, project_member_email_list)
+            project.save()
     except ValueError as e:
         print(e)
 

--- a/projects/projects.py
+++ b/projects/projects.py
@@ -1,6 +1,8 @@
 import uuid
 
 from django.utils import timezone
+from django.core.mail import send_mail
+from django.conf import settings
 
 from .models import Project, AerpawUser
 
@@ -63,8 +65,21 @@ def update_project_members(project, project_member_email_list):
             project_member = AerpawUser.objects.get(oidc_claim_email=member_email)
             project.project_members.add(project_member)
         except AerpawUser.DoesNotExist:
-            project.project_pending_member_emails = project.project_pending_member_emails + member_email+','  
+            project.project_pending_member_emails = project.project_pending_member_emails + member_email+',' 
+    if project.project_pending_member_emails != '':
+        send_pending_memeber_emails(project.project_pending_member_emails)
+
     project.save()
+
+def send_pending_memeber_emails(pending_member_emails):
+    subject = 'AERPAW project sign up'
+    message = 'You received this email because a project PI has added you to the project. Please go to aerpaw.org to login and signup.' 
+    email_from = settings.EMAIL_HOST_USER
+    recipient_list=pending_member_emails.split(',')
+    print(email_from)
+    print(recipient_list)
+    send_mail( subject, message, email_from, recipient_list )
+    
 
 def delete_project_members(project, project_member_id_list):
     """


### PR DESCRIPTION
created a gmail account to send out emails on behalf of AERPAW: aerpaw@gmail.com
The project membership workflow: (0) PI needs to login and signup as PI and wait for the admin to approve before she can create projects. (a) PI adds member emails in ProjectCreate and ProjectUpdate; (2) If the experimenter already signed up, which means here account has been created, the suer will be added to the project; (3) Otherwise, an email from aerpaw.gmail.com will be sent to these pending members. (4) the member login and signup as experimenter; (5) Then the PI needs to update the project to add the user(s).