### PR TITLE
31 add userkey to emulab

### DIFF
--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,7 +1,7 @@
 # accounts/forms.py
 from django import forms
 from django.contrib.auth.forms import UserCreationForm, UserChangeForm
-from .models import AerpawUser, AerpawUserSignup
+from .models import AerpawUser, AerpawUserSignup, AerpawUserCredential
 
 
 class AerpawUserCreationForm(UserCreationForm):
@@ -23,3 +23,10 @@ class AerpawUserSignupForm(forms.ModelForm):
     class Meta:
         model = AerpawUserSignup
         fields = ('user', 'name', 'title', 'organization', 'description', 'userRole', 'publickey')
+
+
+class AerpawUserCredentialForm(forms.ModelForm):
+
+    class Meta:
+        model = AerpawUserCredential
+        fields = ('publickey',)

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -22,4 +22,4 @@ class AerpawUserSignupForm(forms.ModelForm):
 
     class Meta:
         model = AerpawUserSignup
-        fields = ('user', 'name', 'title', 'organization', 'description', 'userRole')
+        fields = ('user', 'name', 'title', 'organization', 'description', 'userRole', 'publickey')

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -49,6 +49,9 @@ class AerpawUser(AbstractUser):
     oidc_claim_acr = models.CharField(max_length=255)
     oidc_claim_entitlement = models.CharField(max_length=255)
 
+    # ssh public key
+    publickey = models.TextField(null=True)
+
     def __str__(self):
         return self.oidc_claim_name + ' (' + self.username + ')'
 
@@ -69,10 +72,11 @@ class AerpawUserSignup(models.Model):
     title = models.CharField(max_length=255)
     organization = models.CharField(max_length=255)
     description = models.TextField()
-    userRole=models.CharField(
+    userRole = models.CharField(
       max_length=64,
       choices=AerpawUserRoleChoice.choices(),
     )
+    publickey = models.TextField(null=True)
 
     def __str__(self):
         return self.user.oidc_claim_email
@@ -98,6 +102,9 @@ def create_new_signup(request, form):
         signup.description = None
 
     signup.userRole = form.data.getlist('userRole')[0]
+    signup.publickey = form.data.getlist('publickey')[0]
+    request.user.publickey = form.data.getlist('publickey')[0]
+    request.user.save()
     signup.save()
 
     return str(signup.uuid)

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -60,10 +60,12 @@ def is_PI(user):
     print(user.groups.all())
     return user.groups.filter(name='PI').exists()
 
+
 def is_project_member(user,project_group):
     print(user)
     print(user.groups.all())
     return user.groups.filter(name=project_group).exists()
+
 
 class AerpawUserSignup(models.Model):
     uuid = models.UUIDField(primary_key=False, default=uuid.uuid4, editable=False)
@@ -80,6 +82,14 @@ class AerpawUserSignup(models.Model):
 
     def __str__(self):
         return self.user.oidc_claim_email
+
+
+class AerpawUserCredential(models.Model):
+    publickey = models.TextField(null=True)
+
+    def __str__(self):
+        return self.publickey
+
 
 def create_new_signup(request, form):
     """
@@ -108,3 +118,15 @@ def create_new_signup(request, form):
     signup.save()
 
     return str(signup.uuid)
+
+
+def update_credential(request, form):
+    """
+
+    :param request:
+    :param form:
+    :return:
+    """
+    request.user.publickey = form.data.getlist('publickey')[0]
+    request.user.save()
+    return str(request.user.publickey)

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,4 +6,5 @@ from . import views
 urlpatterns = [
     path('profile', views.profile, name='profile'),
     path('signup', views.signup, name='signup'),
+    path('credential', views.credential, name='credential'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,8 +1,9 @@
 # accounts/views.py
 
 from django.shortcuts import render, redirect, get_object_or_404
-from .models import create_new_signup
-from .forms import AerpawUserSignupForm
+from .models import create_new_signup, update_credential
+from .forms import AerpawUserSignupForm, AerpawUserCredentialForm
+
 
 def profile(request):
     """
@@ -12,6 +13,7 @@ def profile(request):
     """
     user = request.user
     return render(request, 'profile.html', {'user': user})
+
 
 def signup(request):
     """
@@ -26,5 +28,22 @@ def signup(request):
             signup_uuid = create_new_signup(request, form)
             return redirect('home')
     else:
-        form =AerpawUserSignupForm()
+        form = AerpawUserSignupForm()
     return render(request, 'signup.html', {'form': form})
+
+
+def credential(request):
+    """
+
+    :param request:
+    :return:
+    """
+
+    if request.method == "POST":
+        form = AerpawUserCredentialForm(request.POST)
+        if form.is_valid():
+            update_credential(request, form)
+            return redirect('home')
+    else:
+        form = AerpawUserCredentialForm()
+    return render(request, 'credential.html', {'form': form})

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -192,6 +192,8 @@ def initiate_emulab_instance(request, experiment):
     experiment_body = aerpawgw_client.Experiment(name=experiment.name,
                                                  profile=emulab_profile_name,
                                                  cluster=emulab_location_to_urn(location))
+    experiment.key_inserted = False
+    experiment.save()
     try:
         # create a experiment
         logger.warning(experiment_body)
@@ -227,6 +229,12 @@ def query_emulab_instance_status(request, experiment):
         logger.warning('emulab_experiment:')
         logger.warning(emulab_experiment)
         logger.warning('experiment status on emulab: {}'.format(emulab_experiment.status))
+
+        if emulab_experiment.status == 'ready' and not experiment.key_inserted:
+            userid = request.user.username.split('@')[0]
+            insert_user_to_emulab(request, userid, request.user.publickey, experiment)
+            experiment.key_inserted = True
+            experiment.save()
         return emulab_experiment.status
     except ApiException as e:
         logger.warning('experiment status on emulab: {}'.format('not_started'))
@@ -255,6 +263,8 @@ def terminate_emulab_instance(request, experiment):
     try:
         # delete experiment
         api_instance.delete_experiment(experiment.name)
+        experiment.key_inserted = False
+        experiment.save()
     except ApiException as e:
         logger.warning("Exception when calling ExperimentApi->delete_experiment: %s\n" % e)
     return True
@@ -279,6 +289,28 @@ def get_emulab_manifest(request, experiment):
         logger.error("Exception when calling ResourcesApi->list_resources: %s\n" % e)
         exp_resources = None
     return exp_resources
+
+
+def insert_user_to_emulab(request, user, pubkey, experiment):
+    """
+    Insert user and pubkey to emulab instance.
+
+    :param request:
+    :param user: str
+    :param pubkey: str
+    :param experiment:
+    :return: None
+    """
+    api_instance = aerpawgw_client.UserApi()
+    body = aerpawgw_client.Userkey(user, pubkey)
+    try:
+        # add/update user and sshkey on experiment nodes
+        logger.warning("insert user %s and public key to the instance\n" % user)
+        api_instance.adduser(body, experiment.name)
+
+    except ApiException as e:
+        logger.error("Exception when calling UserApi->adduser: %s\n" % e)
+
 
 
 '''

--- a/experiments/experiments.py
+++ b/experiments/experiments.py
@@ -134,6 +134,11 @@ def delete_existing_experiment(request, experiment):
     :return:
     """
     try:
+        if experiment.profile is not None and is_emulab_profile(experiment.stage):
+            # instance on emulab should be terminated first
+            emulab_deleted = terminate_emulab_instance(request, experiment)
+            if emulab_deleted is False:
+                return False
         experiment.delete()
         return True
     except Exception as e:

--- a/experiments/models.py
+++ b/experiments/models.py
@@ -85,6 +85,8 @@ class Experiment(models.Model):
         Profile, related_name='experiment_profile',blank=True, null=True, on_delete=models.SET_NULL
     )
 
+    key_inserted = models.BooleanField(default=False)
+
     class Meta:
         verbose_name = 'AERPAW Experiment'
 

--- a/resources/resources.py
+++ b/resources/resources.py
@@ -176,14 +176,14 @@ def import_cloud_resources(request):
     total_cloud_resources = {}
     avail_cloud_resources = {}
 
-    logger.warning('parsing emulab resources:')
+    logger.info('parsing emulab resources:')
     for emulab_node in emulab_resources:
         end_index = emulab_node.component_id.find('node')  # "urn:publicid:IDN+exogeni.net+node+pc1"
         location_urn = emulab_node.component_id[:end_index-1]
         location = emulab_urn_to_location(location_urn)
         key = location + ',' + emulab_node.type
-        logger.warning('component_name = {}, location_urn = {}, key = {}'.format(
-            emulab_node.component_name, location_urn, key))
+        logger.warning('component_name = {}, location_urn = {}, key = {}, available = {}'.format(
+            emulab_node.component_name, location_urn, key, emulab_node.available))
 
         if key in total_cloud_resources:
             total_cloud_resources[key] += 1
@@ -198,6 +198,8 @@ def import_cloud_resources(request):
 
     logger.warning("total_cloud_resources:{}".format(total_cloud_resources))
     logger.warning("avail_cloud_resources:{}".format(avail_cloud_resources))
+    logger.warning("portal should calculate the available counts by reservation, " +
+                   "the avail_cloud_resources returned by emulab should just be reference \n")
 
     # create or update resources in database
     for key in total_cloud_resources.keys():

--- a/templates/base/navbar.html
+++ b/templates/base/navbar.html
@@ -43,7 +43,7 @@
                     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
                         <a class="dropdown-item" href="{% url 'profile' %}">User Profile</a>
                         <a class="dropdown-item" href="{% url 'signup' %}">User Signup</a>
-                        <a class="dropdown-item" href="{% url 'signup' %}">Generate Credentials</a>
+                        <a class="dropdown-item" href="{% url 'credential' %}">Upload Credential</a>
                     </div>
                 </li>
                 <li class="nav-item">

--- a/templates/users/credential.html
+++ b/templates/users/credential.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}
+    User Credentials
+{% endblock %}
+
+{% block content %}
+    {% if user.is_authenticated %}
+        <div class="container">
+            <h2>User Credentials</h2>
+            username: {{user.username}} <br>
+            <form method="POST" class="post-form">
+                {% csrf_token %}
+                {{ form.as_p }}
+                <input class="btn btn-success mr-2" type="submit" value="Save"/>
+                <button class="btn btn-secondary" onclick="javascript:history.back();">Cancel</button>
+            </form>
+        </div>
+    {% else %}
+        <div class="container">
+            <p>You are not currently logged in or are not authorized to view this page</p>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/templates/users/profile.html
+++ b/templates/users/profile.html
@@ -40,6 +40,7 @@
   is_superuser: {{user.is_superuser}} <br>
   last_login: {{user.last_login}} <br>
   date_joined: {{user.date_joined}} <br>
+  publickey: {{user.publickey}} <br>
   <br>
 
   <b>universally unique identifier for user within infrastructure</b><br>


### PR DESCRIPTION
- Adding a menu and page for user to upload public key, as well as introducing the publickey field in sign-up form. 
- Use the new adduser API of aerpaw-gateway to push user/key into emulab instances.

