### PR TITLE
support non-emulab geni-lib script profile

### DIFF
--- a/examples/1-fixnode.py
+++ b/examples/1-fixnode.py
@@ -1,0 +1,23 @@
+"""An example of constructing a profile with one physical node running the default OS.
+
+Instructions:
+Log into your PC and poke around. You have root access via `sudo`. Any work you do on your PC will be lost when it terminates."""
+
+# Import the Portal object.
+import geni.portal as portal
+
+# Create a portal object,
+pc = portal.Context()
+
+# Create a Request object to start building the RSpec.
+request = pc.makeRequestRSpec()
+
+# Node node1
+node1 = request.RawPC('node1')
+node1.hardware_type = "FixedNode"
+node1.component_id= "CC1"
+node1.disk_image = "urn:publicid:IDN+emulab.net+image+emulab-ops//UBUNTU20-64-STD"
+
+# Print the generated rspec
+pc.printRequestRSpec(request)
+

--- a/examples/2-fixnode.py
+++ b/examples/2-fixnode.py
@@ -1,0 +1,33 @@
+"""An example of constructing a profile with one physical node running the default OS.
+
+Instructions:
+Log into your PC and poke around. You have root access via `sudo`. Any work you do on your PC will be lost when it terminates."""
+
+# Import the Portal object.
+import geni.portal as portal
+
+# Create a portal object,
+pc = portal.Context()
+
+# Create a Request object to start building the RSpec.
+request = pc.makeRequestRSpec()
+
+# Node node1
+node1 = request.RawPC('node1')
+node1.hardware_type = "FixedNode"
+node1.component_id= "CC1"
+node1.disk_image = "UBUNTU20-64-STD"
+
+
+node2 = request.RawPC("node2")
+node2.hardware_type = "FixedNode"
+node2.component_id= "CC2"
+node2.disk_image = "UBUNTU20-64-STD"
+
+
+# Create a link between them
+link1 = request.Link(members = [node1, node2])
+
+# Print the generated rspec
+pc.printRequestRSpec(request)
+

--- a/experiments/views.py
+++ b/experiments/views.py
@@ -38,7 +38,7 @@ def experiment_create(request):
             project=project_qs[0]
         else:
             return redirect('/')
-        
+
     form = ExperimentCreateForm(request.POST,project=project,experimenter=experimenter)
 
     if form.is_valid():
@@ -65,6 +65,8 @@ def experiment_detail(request, experiment_uuid):
         # 'created', 'provisioning', 'provisioned', 'ready', 'failed', 'teriminating', 'not_started'
         if status == 'provisioned':
             status = 'booting'  # for better user understanding
+    else:
+        status = 'idle' # temporary, might want to change it
 
     return render(request, 'experiment_detail.html',
                   {'experiment': experiment,
@@ -88,14 +90,14 @@ def experiment_update(request, experiment_uuid):
             experiment = form.save(commit=False)
             experiment_uuid = update_existing_experiment(request, experiment, form)
             new_stage = experiment.stage
-            
+
             if stage != new_stage:
                 experiment.stage = new_stage
                 send_exepriment_update_email(experiment)
             return redirect('experiment_detail', experiment_uuid=str(experiment.uuid))
     else:
         form = ExperimentUpdateForm(instance=experiment)
-        
+
     return render(request, 'experiment_update.html',
                   {
                       'form': form, 'experiment_uuid': str(experiment_uuid),
@@ -131,6 +133,10 @@ def experiment_initiate(request, experiment_uuid):
     """
     experiment = get_object_or_404(Experiment, uuid=UUID(str(experiment_uuid)))
     experiment_reservations = experiment.reservation_of_experiment
+
+    if not is_emulab_profile(experiment.stage):
+        return experiment_manifest(request, experiment.uuid)
+
     if request.method == "POST":
         is_success = initiate_emulab_instance(request, experiment)
         if is_success:
@@ -154,6 +160,8 @@ def experiment_manifest(request, experiment_uuid):
     manifest = None
     if experiment.stage.upper() == 'DEVELOPMENT':
         manifest = get_emulab_manifest(request, experiment)
+    else:
+        manifest = get_non_emulab_manifest(request, experiment)
 
     if manifest is not None:
         logger.warning(manifest)


### PR DESCRIPTION
- need to use with latest aerpaw-gateway and install latest aerpaw-gateway-client
- script will be sent to aerpaw-gateway to parse with new api
- the portal will add IP and hostname information to the nodes in response of aerpaw-gateway, then return to user.
