### PR TITLE
Minor modifications to alleviate some reported issues

### DIFF
--- a/aerpaw-portal.ini
+++ b/aerpaw-portal.ini
@@ -9,6 +9,7 @@ max-requests = 5000
 # tune as needed for traffic
 processes = 4
 threads = 2
+buffer-size = 8192
 
 # use for development: local-ssl
 socket = :8000

--- a/portal/apps/experiments/models.py
+++ b/portal/apps/experiments/models.py
@@ -234,7 +234,7 @@ class CanonicalExperimentResource(BaseModel, BaseTimestampModel, models.Model):
     node_vehicle = models.CharField(
         max_length=255,
         choices=NodeVehicle.choices,
-        default=NodeVehicle.VEHICLE_NONE
+        default=NodeVehicle.VEHICLE_NONE if node_type==NodeType.AFRN else NodeVehicle.VEHICLE_UAV
     )
     resource = models.ForeignKey(
         AerpawResource,


### PR DESCRIPTION
- Set defalult vehicle type UAV for APRNs in experiment resources
- Increased default buffer size as some users would occasionally receive an HTTP 502 error after successful authentication/redirect from CILogon due to threshold exceeded