### PR TITLE
updated the user manual links

### DIFF
--- a/portal/templates/portal/home.html
+++ b/portal/templates/portal/home.html
@@ -51,7 +51,7 @@
             <strong>User manuals, tutorials, and other relevant documentation can be found at the following links;
                 please refer to relevant instructions before attempting to use this Portal.</strong><br>
             - <a href="https://www.aerpaw.org/" target="_blank">AERPAW Main Site</a> <br>
-            - <a href="https://sites.google.com/ncsu.edu/aerpaw-wiki/" target="_blank">AERPAW User Manual</a><br>
+            - <a href="https://sites.google.com/ncsu.edu/aerpaw-user-manual/1-aerpaw-overview" target="_blank">AERPAW User Manual</a><br>
             - <a
                 href="https://sites.google.com/ncsu.edu/aerpaw-wiki/aerpaw-user-manual/2-experiment-lifecycle-workflows/2-5-acceptable-use-policy-aup"
                 target="_blank">AERPAW Acceptable Use Policy</a>


### PR DESCRIPTION
Updated the user manual link on the portal home page to the current user manual at https://sites.google.com/ncsu.edu/aerpaw-user-manual/1-aerpaw-overview 